### PR TITLE
minimal fixes to logical errors that are likely to cause these scripts to produce bad results

### DIFF
--- a/LDRdbWriteGate.py
+++ b/LDRdbWriteGate.py
@@ -26,8 +26,7 @@ mcp = Adafruit_MCP3008.MCP3008(spi=SPI.SpiDev(SPI_PORT, SPI_DEVICE))
 
 try:
 	while True:
-		curr_date = datetime.now().strftime("%Y-%m-%d")
-		curr_time = datetime.now().strftime("%H:%M:%S")
+		curr_date = datetime.now()
 
 		# Read current LDR value from ADC
 		#curr_ldr = mcp.read_adc(0)
@@ -43,9 +42,9 @@ try:
 		cursor = db.cursor()
 
 		# Prepare SQL query to INSERT a record into the database.
-		sql = "INSERT INTO LDRSTATS (date, time, gatecount) VALUES ('%s', '%s', '%d')" % (curr_date, curr_time, count)
+		sql = "INSERT INTO LDRSTATS (datetime, gatecount) VALUES ('%s', '%d')" % (curr_date.isoformat(' '), count)
 
-		if any( [datetime.now().strftime("%M") == "00", int(datetime.now().strftime("%M")) == 10, int(datetime.now().strftime("%M")) == 20, int(datetime.now().strftime("%M")) == 30, int(datetime.now().strftime("%M")) == 40, int(datetime.now().strftime("%M")) == 50] ) and (datetime.now().strftime("%S") == "00"):
+		if (curr_date.minute % 10 == 0) and (curr_date.second == 0):
 			try:
 				# Execute the SQL command
 				cursor.execute(sql)

--- a/PIRdbWriteGate.py
+++ b/PIRdbWriteGate.py
@@ -3,7 +3,9 @@
 #!/usr/bin/python
 
 import sys
-import time, MySQLdb
+import MySQLdb
+from time import sleep
+from datetime import datetime
 import RPi.GPIO as GPIO
 
 # Set RPi GPIO Mode
@@ -31,15 +33,13 @@ try:
 		# prepare a cursor object using cursor() method
 		cursor = db.cursor()
 
-		curr_date = time.strftime("%Y-%m-%d")
-		curr_time = time.strftime("%H:%M:%S")
-
+		curr_date = datetime.now()
 
 		# Prepare SQL query to INSERT a record into the database.
-		sql = "INSERT INTO PIRSTATS (date, time, gatecount) VALUES ('%s', '%s', '%d')" % (curr_date, curr_time, count)
+		sql = "INSERT INTO PIRSTATS (datetime, gatecount) VALUES ('%s', '%d')" % (curr_date.isoformat(' '), count)
 
 
-		if any( [time.strftime("%M") == "00", int(time.strftime("%M")) == 10, int(time.strftime("%M")) == 20, int(time.strftime("%M")) == 30, int(time.strftime("%M")) == 40, int(time.strftime("%M")) == 50]) and (time.strftime("%S") == "00"):
+		if (curr_date.minute % 10 == 0) and (curr_date.second == 0):
 			try:
 				# Execute the SQL command
 				cursor.execute(sql)
@@ -52,7 +52,7 @@ try:
 		# Disconnect from database server
 		db.close()
 
-		time.sleep(1)
+		sleep(1)
 except KeyboardInterrupt:
 	print ("\nCtrl-C pressed cleaning up GPIO")
 	GPIO.cleanup()

--- a/UltraSonicdbWriteGate.py
+++ b/UltraSonicdbWriteGate.py
@@ -1,7 +1,9 @@
 # Written By Johnathan Cintron and Devlyn Courtier for the HCCC Library
 
 import sys
-import time, MySQLdb
+import MySQLdb
+from datetime import datetime
+from time import sleep
 import RPi.GPIO as GPIO
 
 ultraSonicConst = "95"
@@ -14,7 +16,7 @@ GPIO.setmode(GPIO.BCM)
 TRIG = 23
 ECHO = 24
 
-# Setup GPIO in and out 
+# Setup GPIO in and out
 GPIO.setup(TRIG, GPIO.OUT)
 GPIO.setup(ECHO, GPIO.IN)
 
@@ -28,14 +30,13 @@ cursor = db.cursor()
 
 try:
 	while True:
-		curr_date = time.strftime("%Y-%m-%d")
-		curr_time = time.strftime("%H:%M:%S")
+		curr_date = datetime.now()
 
 		GPIO.output(TRIG, False)
-		time.sleep(0.5)
+		sleep(0.5)
 
 		GPIO.output(TRIG, True)
-		time.sleep(0.00001)
+		sleep(0.00001)
 		GPIO.output(TRIG, False)
 
 		while GPIO.input(ECHO) == 0:
@@ -49,7 +50,7 @@ try:
 		distance = pulse_duration * 17150
 
 		distance = round(distance, 2)
-	
+
 		if distance < 120:
 			count = count + 1
 
@@ -62,11 +63,10 @@ try:
 
 		# Prepare SQL query to INSERT a record into the database.
 
-		#if any( [int(time.strftime("%H")) == 8, int(time.strftime("%H")) == 15, int(time.strftime("%H")) == 22] ) and (int(time.strftime("%M")) == 0):
-		if any( [time.strftime("%M") == "00", int(time.strftime("%M")) == 10, int(time.strftime("%M")) == 20, int(time.strftime("%M")) == 30, int(time.strftime("%M")) == 40, int(time.strftime("%M")) == 50]) and (time.strftime("%S") == "00"):
+		if (curr_date.minute % 10 == 0) and (curr_date.second == 0):
 			try:
 				# Create SQL Query
-				sql = "INSERT INTO ULTRASTATS (date, time, gatecount) VALUES ('%s', '%s', '%d')" % (curr_date, curr_time, count)
+				sql = "INSERT INTO ULTRASTATS (datetime, gatecount) VALUES ('%s', '%d')" % (curr_date.isoformat(' '), count)
 				# Execute the SQL command
 				cursor.execute(sql)
 				# Commit your changes in the database
@@ -75,7 +75,7 @@ try:
 				# Rollback in case there is any error
 				db.rollback()
 
-		time.sleep(0.5)
+		sleep(0.5)
 except KeyboardInterrupt:
 	db.close()
 	print("\nCtrl-C pressed cleaning up GPIO")

--- a/UltraSonicdbWriteGate.py
+++ b/UltraSonicdbWriteGate.py
@@ -3,7 +3,7 @@
 import sys
 import MySQLdb
 from datetime import datetime
-from time import sleep
+from time import sleep, time
 import RPi.GPIO as GPIO
 
 ultraSonicConst = "95"
@@ -40,10 +40,10 @@ try:
 		GPIO.output(TRIG, False)
 
 		while GPIO.input(ECHO) == 0:
-			pulse_start = time.time()
+			pulse_start = time()
 
 		while GPIO.input(ECHO) == 1:
-			pulse_end = time.time()
+			pulse_end = time()
 
 		pulse_duration = pulse_end - pulse_start
 


### PR DESCRIPTION
- stored date and time as SINGLE datetime object.  Datetimes are insertable into a MySQL database if iso-formatted with a single space between date and time components

- called datetime.now() a SINGLE time per loop.

- fixed logical error in the if statement controlling whether or not the data is written to the database.  Repeated calls to datetime.now() in the original logic will return a different now() each time, and the repeated conversions to and comparisons to strings are likely to make it so that there is almost NEVER a time when the datetime.now().strptime("%S") == "00" after the first 6 checks of the minute.  replaced by checking that the seconds == 0 without converting to string, checked minute using modulous (%) operator, minute % 10 == 0 means that the remainder after dividing minute by 10 is 0 (i.e. it is a 10-minute mark of an hour)